### PR TITLE
resources/talent: refactor data structure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,7 +12,7 @@ dependencies = [
  "params 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "router 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rs-es 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.8.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.8.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_codegen 0.8.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.8.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -40,7 +40,7 @@ dependencies = [
  "iron 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "persistent 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "plugin 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.8.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.8.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -74,7 +74,7 @@ dependencies = [
  "openssl 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "gcc"
-version = "0.3.40"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -128,7 +128,7 @@ dependencies = [
  "language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-verify 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -137,7 +137,7 @@ dependencies = [
  "traitobject 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -146,8 +146,8 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "matches 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-bidi 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-normalization 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-bidi 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-normalization 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -164,7 +164,7 @@ dependencies = [
  "num_cpus 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "plugin 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "typemap 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -198,7 +198,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -238,7 +238,7 @@ name = "memchr"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -350,15 +350,15 @@ name = "num_cpus"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num_cpus"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -377,9 +377,9 @@ version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gcc 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-sys 0.7.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-sys-extras 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -390,7 +390,7 @@ version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gdi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "libressl-pnacl-sys 2.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "user32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -401,8 +401,8 @@ name = "openssl-sys-extras"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-sys 0.7.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -526,7 +526,7 @@ name = "rand"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -541,7 +541,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "iron 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "route-recognizer 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -552,11 +552,11 @@ dependencies = [
  "hyper 0.9.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "maplit 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.8.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.8.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_codegen 0.8.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.8.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -564,8 +564,8 @@ name = "rust-crypto"
 version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -591,7 +591,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "0.8.19"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -625,7 +625,7 @@ dependencies = [
  "dtoa 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.8.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.8.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -659,7 +659,7 @@ name = "syntex_errors"
 version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "syntex_pos 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -681,7 +681,7 @@ version = "0.44.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "syntex_errors 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -713,7 +713,7 @@ version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -722,7 +722,7 @@ name = "toml"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 0.8.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.8.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "matches 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -766,7 +766,7 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -784,7 +784,7 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "1.2.3"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "idna 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -799,7 +799,7 @@ dependencies = [
  "bodyparser 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "iron 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "plugin 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -831,7 +831,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0e3d6405328b6edb412158b3b7710e2634e23f3614b9bb1c412df7952489a626"
 "checksum dtoa 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0dd841b58510c9618291ffa448da2e4e0f699d984d436122372f446dae62263d"
 "checksum error 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "a6e606f14042bb87cc02ef6a14db6c90ab92ed6f62d87e69377bc759fd7987cc"
-"checksum gcc 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)" = "872db9e59486ef2b14f8e8c10e9ef02de2bccef6363d7f34835dedb386b3d950"
+"checksum gcc 0.3.41 (registry+https://github.com/rust-lang/crates.io-index)" = "3689e1982a563af74960ae3a4758aa632bb8fd984cfc3cc3b60ee6109477ab6e"
 "checksum gdi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0912515a8ff24ba900422ecda800b52f4016a56251922d397c576bf92c690518"
 "checksum hpack 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d2da7d3a34cf6406d9d700111b8eafafe9a251de41ae71d8052748259343b58"
 "checksum httparse 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a6e7a63e511f9edffbab707141fbb8707d1a3098615fb2adbd5769cdfcc9b17d"
@@ -843,7 +843,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "cf186d1a8aa5f5bee5fd662bc9c1b949e0259e1bcc379d1f006847b0080c7417"
 "checksum lazy_static 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6abe0ee2e758cd6bc8a2cd56726359007748fbf4128da998b65d0b70f881e19b"
-"checksum libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "a51822fc847e7a8101514d1d44e354ba2ffa7d4c194dcab48870740e327cac70"
+"checksum libc 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)" = "9e030dc72013ed68994d1b2cbf36a94dd0e58418ba949c4b0db7eeb70a7a6352"
 "checksum libressl-pnacl-sys 2.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "cbc058951ab6a3ef35ca16462d7642c4867e6403520811f28537a4e2f2db3e71"
 "checksum log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ab83497bf8bf4ed2a74259c1c802351fcd67a65baa86394b6ba73c36f4838054"
 "checksum logger 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3cf2488134e30432708391618d45fbdbf925223b842bba4f962fd03632b9566b"
@@ -862,7 +862,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum num-rational 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "54ff603b8334a72fbb27fe66948aac0abaaa40231b3cecd189e76162f6f38aaf"
 "checksum num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "a16a42856a256b39c6d3484f097f6713e14feacd9bfb02290917904fae46c81c"
 "checksum num_cpus 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "cee7e88156f3f9e19bdd598f8d6c9db7bf4078f99f8381f43a55b09648d1a6e3"
-"checksum num_cpus 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "55aabf4e2d6271a2e4e4c0f2ea1f5b07cc589cc1a9e9213013b54a76678ca4f3"
+"checksum num_cpus 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a225d1e2717567599c24f88e49f00856c6e825a12125181ee42c4257e3688d39"
 "checksum oath 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "61526488a78ec2a48c1f0d88c88c7233855b7c832739a748f904af06018a576f"
 "checksum openssl 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)" = "c4117b6244aac42ed0150a6019b4d953d28247c5dd6ae6f46ae469b5f2318733"
 "checksum openssl-sys 0.7.17 (registry+https://github.com/rust-lang/crates.io-index)" = "89c47ee94c352eea9ddaf8e364be7f978a3bb6d66d73176572484238dd5a5c3f"
@@ -888,7 +888,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "237546c689f20bb44980270c73c3b9edd0891c1be49cc1274406134a66d3957b"
 "checksum rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
 "checksum semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
-"checksum serde 0.8.19 (registry+https://github.com/rust-lang/crates.io-index)" = "58a19c0871c298847e6b68318484685cd51fa5478c0c905095647540031356e5"
+"checksum serde 0.8.21 (registry+https://github.com/rust-lang/crates.io-index)" = "7b7c6bf11cf766473ea1d53eb4e3bc4e80f31f50082fc24077cf06f600279a66"
 "checksum serde_codegen 0.8.9 (registry+https://github.com/rust-lang/crates.io-index)" = "da68810d845f8e33a80243c28794650397056cbe7aea4c9c7516f55d1061c94e"
 "checksum serde_codegen_internals 0.8.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1b0115c5c602e81c61b787fb0f0fa76a614f8dbe9100b2b59b7d590155672c80"
 "checksum serde_json 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3f7d3c184d35801fb8b32b46a7d58d57dbcc150b0eb2b46a1eb79645e8ecfd5b"
@@ -907,11 +907,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
 "checksum typemap 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "653be63c80a3296da5551e1bfd2cca35227e13cdd08c6668903ae2f4f77aa1f6"
 "checksum unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "13a5906ca2b98c799f4b1ab4557b76367ebd6ae5ef14930ec841c74aed5f3764"
-"checksum unicode-bidi 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c1f7ceb96afdfeedee42bade65a0d585a6a0106f681b6749c8ff4daa8df30b3f"
-"checksum unicode-normalization 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "26643a2f83bac55f1976fb716c10234485f9202dcd65cfbdf9da49867b271172"
+"checksum unicode-bidi 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b61814f3e7fd0e0f15370f767c7c943e08bc2e3214233ae8f88522b334ceb778"
+"checksum unicode-normalization 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5e94e9f6961090fcc75180629c4ef33e5310d6ed2c0dd173f4ca63c9043b669e"
 "checksum unicode-xid 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "36dff09cafb4ec7c8cf0023eb0b686cb6ce65499116a12201c9e11840ca01beb"
 "checksum unsafe-any 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b351086021ebc264aea3ab4f94d61d889d98e5e9ec2d985d993f50133537fd3a"
-"checksum url 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "48ccf7bd87a81b769cf84ad556e034541fb90e1cd6d4bc375c822ed9500cd9d7"
+"checksum url 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f024e241a55f5c88401595adc1d4af0c9649e91da82d0e190fe55950231ae575"
 "checksum urlencoded 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5ddcf2d3a0beedb5cdf50cabc521ab76a994907877a1d91d996c251d42c70e2e"
 "checksum user32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ef4711d107b21b410a3a974b1204d9accc8b10dad75d8324b5d755de1617d47"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -16,14 +16,14 @@ pub trait Resource: Send + Sync + Any + Serialize + Deserialize + Debug {
   type Results: Serialize + Deserialize;
 
   /// Respond to GET requests returning an array with found ids
-  fn search(mut es: &mut Client, default_index: &str, params: &Map) -> Self::Results;
+  fn search(es: &mut Client, default_index: &str, params: &Map) -> Self::Results;
 
   /// Respond to POST requests indexing given entity
-  fn index(mut es: &mut Client, index: &str, resources: Vec<Self>) -> Result<BulkResult, EsError>;
+  fn index(es: &mut Client, index: &str, resources: Vec<Self>) -> Result<BulkResult, EsError>;
 
   /// Respond to DELETE requests on given id deleting it from given index
-  fn delete(mut es: &mut Client, id: &str, index: &str) -> Result<DeleteResult, EsError>;
+  fn delete(es: &mut Client, id: &str, index: &str) -> Result<DeleteResult, EsError>;
 
   /// Respond to DELETE requests rebuilding and reindexing given index
-  fn reset_index(mut es: &mut Client, index: &str) -> Result<MappingResult, EsError>;
+  fn reset_index(es: &mut Client, index: &str) -> Result<MappingResult, EsError>;
 }

--- a/src/resources/talent.rs
+++ b/src/resources/talent.rs
@@ -51,8 +51,9 @@ pub struct FoundTalent {
   pub avatar_url:                    String,
   pub work_locations:                Vec<String>,
   pub current_location:              String,
-  pub salary_expectations:           Option<String>,
-  pub roles_experiences:             Vec<RolesExperience>
+  pub salary_expectations:           String,
+  pub roles_experiences:             Vec<RolesExperience>,
+  pub latest_position:               String
 }
 
 /// A struct that joins `desired_work_roles` and `desired_work_roles_experience`.
@@ -88,7 +89,8 @@ impl From<Box<Talent>> for FoundTalent {
       work_locations:                talent.work_locations.to_owned(),
       current_location:              talent.current_location.to_owned(),
       salary_expectations:           talent.salary_expectations.to_owned(),
-      roles_experiences:             roles_experiences
+      roles_experiences:             roles_experiences,
+      latest_position:               talent.latest_position.to_owned()
     }
   }
 }
@@ -116,7 +118,8 @@ pub struct Talent {
   pub blocked_companies:             Vec<u32>,
   pub work_experiences:              Vec<String>, // past work experiences (i.e. ["Frontend developer", "SysAdmin"])
   pub avatar_url:                    String,
-  pub salary_expectations:           Option<String>
+  pub salary_expectations:           String,
+  pub latest_position:               String // the very last experience_entries#position
 }
 
 impl Talent {
@@ -482,6 +485,11 @@ impl Resource for Talent {
         "salary_expectations" => hashmap! {
           "type"  => "string",
           "index" => "not_analyzed"
+        },
+
+        "latest_position" => hashmap! {
+          "type"  => "string",
+          "index" => "not_analyzed"
         }
       }
     };
@@ -630,7 +638,8 @@ mod tests {
         weight:                        -5,
         blocked_companies:             vec![],
         avatar_url:                    "https://secure.gravatar.com/avatar/a0b9ad63fb35d210a218c317e0a6284e.jpg?s=250".to_owned(),
-        salary_expectations:           Some("< 60.000€".to_owned())
+        salary_expectations:           "< 60.000€".to_owned(),
+        latest_position:               "Developer".to_owned()
       },
 
       Talent {
@@ -654,7 +663,8 @@ mod tests {
         weight:                        6,
         blocked_companies:             vec![22],
         avatar_url:                    "https://secure.gravatar.com/avatar/a0b9ad63fb35d210a218c317e0a6284e.jpg?s=250".to_owned(),
-        salary_expectations:           None
+        salary_expectations:           "".to_owned(),
+        latest_position:               "".to_owned()
       },
 
       Talent {
@@ -678,7 +688,8 @@ mod tests {
         weight:                        6,
         blocked_companies:             vec![],
         avatar_url:                    "https://secure.gravatar.com/avatar/a0b9ad63fb35d210a218c317e0a6284e.jpg?s=250".to_owned(),
-        salary_expectations:           None
+        salary_expectations:           "".to_owned(),
+        latest_position:               "".to_owned()
       },
 
       Talent {
@@ -702,7 +713,8 @@ mod tests {
         weight:                        0,
         blocked_companies:             vec![],
         avatar_url:                    "https://secure.gravatar.com/avatar/a0b9ad63fb35d210a218c317e0a6284e.jpg?s=250".to_owned(),
-        salary_expectations:           None
+        salary_expectations:           "".to_owned(),
+        latest_position:               "".to_owned()
       },
 
       Talent {
@@ -726,7 +738,8 @@ mod tests {
         weight:                        0,
         blocked_companies:             vec![],
         avatar_url:                    "https://secure.gravatar.com/avatar/a0b9ad63fb35d210a218c317e0a6284e.jpg?s=250".to_owned(),
-        salary_expectations:           None
+        salary_expectations:           "".to_owned(),
+        latest_position:               "".to_owned()
       }
     ];
 
@@ -1070,7 +1083,8 @@ mod tests {
       \"blocked_companies\":[99],
       \"work_experiences\":[\"Frontend developer\", \"SysAdmin\"],
       \"avatar_url\":\"https://secure.gravatar.com/avatar/47ac43379aa70038a9adc8ec88a1241d?s=250&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fa0b9ad63fb35d210a218c317e0a6284e%3Fs%3D250\",
-      \"salary_expectations\":\"30.000€ - 40.000€\"
+      \"salary_expectations\":\"30.000€ - 40.000€\",
+      \"latest_position\":\"Developer\"
     }".to_owned();
 
     let resource: Result<Talent, _> = serde_json::from_str(&payload);

--- a/src/resources/talent.rs
+++ b/src/resources/talent.rs
@@ -46,14 +46,47 @@ impl From<SearchHitsHitsResult<Talent>> for SearchResult {
 /// A representation of `Talent` with limited fields.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct FoundTalent {
-  pub id: u32
+  pub id:                            u32,
+  pub headline:                      String,
+  pub avatar_url:                    String,
+  pub work_locations:                Vec<String>,
+  pub salary_expectations:           Option<String>,
+  pub roles_experiences:             Vec<RolesExperience>
+}
+
+/// A struct that joins `desired_work_roles` and `desired_work_roles_experience`.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct RolesExperience {
+  pub role:       String,
+  pub experience: String
+}
+
+impl RolesExperience {
+  fn new(role: &str, experience: Option<&String>) -> RolesExperience {
+    RolesExperience {
+      role:       role.to_owned(),
+      experience: experience.map(|e| e.to_owned()).unwrap_or("".to_owned())
+    }
+  }
 }
 
 /// Convert a `Box<Talent>` returned by ElasticSearch into a `FoundTalent`.
 impl From<Box<Talent>> for FoundTalent {
   fn from(talent: Box<Talent>) -> FoundTalent {
+    let mut roles_experiences = vec![];
+
+    for (i, role) in talent.desired_work_roles.iter().enumerate() {
+      let experience = talent.desired_work_roles_experience.get(i);
+      roles_experiences.push(RolesExperience::new(role, experience));
+    }
+
     FoundTalent {
-      id: talent.id
+      id:                            talent.id,
+      headline:                      talent.headline.to_owned(),
+      avatar_url:                    talent.avatar_url.to_owned(),
+      work_locations:                talent.work_locations.to_owned(),
+      salary_expectations:           talent.salary_expectations.to_owned(),
+      roles_experiences:             roles_experiences
     }
   }
 }

--- a/src/resources/talent.rs
+++ b/src/resources/talent.rs
@@ -472,6 +472,16 @@ impl Resource for Talent {
         "blocked_companies" => hashmap! {
           "type"  => "integer",
           "index" => "not_analyzed"
+        },
+
+        "avatar_url" => hashmap! {
+          "type"  => "string",
+          "index" => "not_analyzed"
+        },
+
+        "salary_expectations" => hashmap! {
+          "type"  => "string",
+          "index" => "not_analyzed"
         }
       }
     };

--- a/src/resources/talent.rs
+++ b/src/resources/talent.rs
@@ -55,23 +55,26 @@ pub struct FoundTalent {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Talent {
-  pub id:                 u32,
-  pub accepted:           bool,
-  pub work_roles:         Vec<String>,
-  pub work_roles_vanilla: Option<Vec<String>>,
-  pub work_experience:    String,
-  pub work_locations:     Vec<String>,
-  pub work_authorization: String,
-  pub skills:             Vec<String>,
-  pub summary:            String,
-  pub headline:           String,
-  pub job_titles:         Vec<String>,
-  pub company_ids:        Vec<u32>,
-  pub batch_starts_at:    String,
-  pub batch_ends_at:      String,
-  pub added_to_batch_at:  String,
-  pub weight:             i32,
-  pub blocked_companies:  Vec<u32>
+  pub id:                            u32,
+  pub accepted:                      bool,
+  pub desired_work_roles:            Vec<String>,
+  pub desired_work_roles_vanilla:    Option<Vec<String>>, // not processed by ES
+  pub desired_work_roles_experience: Vec<String>, // experience in the desired work roles
+  pub professional_experience:       String, // i.e. 2..6
+  pub work_locations:                Vec<String>, // wants to work in
+  pub work_authorization:            String, // yes/no/unsure (visa)
+  pub skills:                        Vec<String>,
+  pub summary:                       String,
+  pub headline:                      String,
+  pub contacted_company_ids:         Vec<u32>, // contacted companies
+  pub batch_starts_at:               String,
+  pub batch_ends_at:                 String,
+  pub added_to_batch_at:             String,
+  pub weight:                        i32,
+  pub blocked_companies:             Vec<u32>,
+  pub work_experiences:              Vec<String>, // past work experiences (i.e. ["Frontend developer", "SysAdmin"])
+  pub avatar_url:                    String,
+  pub salary_expectations:           Option<String>
 }
 
 impl Talent {
@@ -127,8 +130,8 @@ impl Talent {
   ///
   /// Considering a single row, the terms inside there are ORred,
   /// while through the rows there is an AND.
-  /// I.e.: given ["Fullstack", "DevOps"] as `work_roles`, found talents
-  /// will present at least one of these roles), but both `work_roles`
+  /// I.e.: given ["Fullstack", "DevOps"] as `desired_work_roles`, found talents
+  /// will present at least one of these roles), but both `desired_work_roles`
   /// and `work_location`, if provided, must be matched successfully.
   pub fn search_filters(params: &Map, epoch: &str) -> Query {
     let company_id = i32_vec_from_params!(params, "company_id");
@@ -142,10 +145,10 @@ impl Talent {
                 },
 
                <Query as VectorOfTerms<String>>::build_terms(
-                 "work_roles_vanilla", &vec_from_params!(params, "work_roles")),
+                 "desired_work_roles_vanilla", &vec_from_params!(params, "desired_work_roles")),
 
                <Query as VectorOfTerms<String>>::build_terms(
-                 "work_experience", &vec_from_params!(params, "work_experience")),
+                 "professional_experience", &vec_from_params!(params, "professional_experience")),
 
                <Query as VectorOfTerms<String>>::build_terms(
                  "work_authorization", &vec_from_params!(params, "work_authorization")),
@@ -164,7 +167,7 @@ impl Talent {
                 .with_must_not(
                    vec![
                      <Query as VectorOfTerms<i32>>::build_terms(
-                       "company_ids", &company_id),
+                       "contacted_company_ids", &company_id),
 
                      <Query as VectorOfTerms<i32>>::build_terms(
                        "blocked_companies", &company_id),
@@ -189,8 +192,8 @@ impl Talent {
                   "skills".to_owned(),
                   "summary".to_owned(),
                   "headline".to_owned(),
-                  "work_roles".to_owned(),
-                  "job_titles".to_owned()
+                  "desired_work_roles".to_owned(),
+                  "work_experiences".to_owned()
                 ], keywords.to_owned())
             .with_type(MatchQueryType::CrossFields)
             .with_tie_breaker(0.0)
@@ -219,7 +222,7 @@ impl Resource for Talent {
     es.bulk(&resources.into_iter()
                       .map(|mut r| {
                           let id = r.id.to_string();
-                          r.work_roles_vanilla = Some(r.work_roles.to_owned());
+                          r.desired_work_roles_vanilla = Some(r.desired_work_roles.to_owned());
                           Action::index(r).with_id(id)
                       })
                       .collect::<Vec<Action<Talent>>>())
@@ -271,8 +274,8 @@ impl Resource for Talent {
       highlight.add_setting("skills".to_owned(),  settings.clone());
       highlight.add_setting("summary".to_owned(), settings.clone());
       highlight.add_setting("headline".to_owned(), settings.clone());
-      highlight.add_setting("work_roles".to_owned(), settings.clone());
-      highlight.add_setting("job_titles".to_owned(), settings);
+      highlight.add_setting("desired_work_roles".to_owned(), settings.clone());
+      highlight.add_setting("work_experiences".to_owned(), settings);
 
       es.search_query()
         .with_indexes(&*index)
@@ -334,19 +337,23 @@ impl Resource for Talent {
           "index" => "not_analyzed"
         },
 
-        "work_roles" => hashmap! {
+        "desired_work_roles" => hashmap! {
           "type"            => "string",
           "analyzer"        => "trigrams",
           "search_analyzer" => "words"
         },
 
-        // TODO: use multi_field
-        "work_roles_vanilla" => hashmap! {
+        "desired_work_roles_vanilla" => hashmap! {
           "type"  => "string",
           "index" => "not_analyzed"
         },
 
-        "work_experience" => hashmap! {
+        "desired_work_roles_experience" => hashmap! {
+          "type"  => "string",
+          "index" => "not_analyzed"
+        },
+
+        "professional_experience" => hashmap! {
           "type"  => "string",
           "index" => "not_analyzed"
         },
@@ -381,13 +388,13 @@ impl Resource for Talent {
           "boost"           => "2.0"
         },
 
-        "job_titles" => hashmap! {
+        "work_experiences" => hashmap! {
           "type"            => "string",
           "analyzer"        => "trigrams",
           "search_analyzer" => "words"
         },
 
-        "company_ids" => hashmap! {
+        "contacted_company_ids" => hashmap! {
           "type"  => "integer",
           "index" => "not_analyzed"
         },
@@ -536,103 +543,118 @@ mod tests {
   pub fn populate_index(mut client: &mut Client) -> bool {
     let talents = vec![
       Talent {
-        id:                 1,
-        accepted:           true,
-        work_roles:         vec![],
-        work_roles_vanilla: None,
-        work_experience:    "1..2".to_owned(),
-        work_locations:     vec!["Berlin".to_owned()],
-        work_authorization: "yes".to_owned(),
-        skills:             vec!["Rust".to_owned(), "HTML5".to_owned(), "HTML".to_owned()],
-        summary:            "I'm a senior Rust developer and sometimes I do also HTML.".to_owned(),
-        headline:           "Backend developer with Rust experience".to_owned(),
-        job_titles:         vec!["Database Administrator".to_owned()],
-        company_ids:        vec![],
-        batch_starts_at:    epoch_from_year!("2006"),
-        batch_ends_at:      epoch_from_year!("2020"),
-        added_to_batch_at:  epoch_from_year!("2006"),
-        weight:             -5,
-        blocked_companies:  vec![]
+        id:                            1,
+        accepted:                      true,
+        desired_work_roles:            vec![],
+        desired_work_roles_vanilla:    None,
+        desired_work_roles_experience: vec![],
+        professional_experience:       "1..2".to_owned(),
+        work_locations:                vec!["Berlin".to_owned()],
+        work_authorization:            "yes".to_owned(),
+        skills:                        vec!["Rust".to_owned(), "HTML5".to_owned(), "HTML".to_owned()],
+        summary:                       "I'm a senior Rust developer and sometimes I do also HTML.".to_owned(),
+        headline:                      "Backend developer with Rust experience".to_owned(),
+        work_experiences:              vec!["Database Administrator".to_owned()],
+        contacted_company_ids:         vec![],
+        batch_starts_at:               epoch_from_year!("2006"),
+        batch_ends_at:                 epoch_from_year!("2020"),
+        added_to_batch_at:             epoch_from_year!("2006"),
+        weight:                        -5,
+        blocked_companies:             vec![],
+        avatar_url:                    "https://secure.gravatar.com/avatar/a0b9ad63fb35d210a218c317e0a6284e.jpg?s=250".to_owned(),
+        salary_expectations:           Some("< 60.000€".to_owned())
       },
 
       Talent {
-        id:                 2,
-        accepted:           true,
-        work_roles:         vec![],
-        work_roles_vanilla: None,
-        work_experience:    "8+".to_owned(),
-        work_locations:     vec!["Rome".to_owned(),"Berlin".to_owned()],
-        work_authorization: "yes".to_owned(),
-        skills:             vec!["Rust".to_owned(), "HTML5".to_owned(), "Java".to_owned()],
-        summary:            "I'm a java dev with some tricks up my sleeves".to_owned(),
-        headline:           "Senior Java engineer".to_owned(),
-        job_titles:         vec![],
-        company_ids:        vec![],
-        batch_starts_at:    epoch_from_year!("2006"),
-        batch_ends_at:      epoch_from_year!("2020"),
-        added_to_batch_at:  epoch_from_year!("2006"),
-        weight:             6,
-        blocked_companies:  vec![22]
+        id:                            2,
+        accepted:                      true,
+        desired_work_roles:            vec![],
+        desired_work_roles_vanilla:    None,
+        desired_work_roles_experience: vec![],
+        professional_experience:       "8+".to_owned(),
+        work_locations:                vec!["Rome".to_owned(),"Berlin".to_owned()],
+        work_authorization:            "yes".to_owned(),
+        skills:                        vec!["Rust".to_owned(), "HTML5".to_owned(), "Java".to_owned()],
+        summary:                       "I'm a java dev with some tricks up my sleeves".to_owned(),
+        headline:                      "Senior Java engineer".to_owned(),
+        work_experiences:              vec![],
+        contacted_company_ids:         vec![],
+        batch_starts_at:               epoch_from_year!("2006"),
+        batch_ends_at:                 epoch_from_year!("2020"),
+        added_to_batch_at:             epoch_from_year!("2006"),
+        weight:                        6,
+        blocked_companies:             vec![22],
+        avatar_url:                    "https://secure.gravatar.com/avatar/a0b9ad63fb35d210a218c317e0a6284e.jpg?s=250".to_owned(),
+        salary_expectations:           None
       },
 
       Talent {
-        id:                 3,
-        accepted:           false,
-        work_roles:         vec![],
-        work_roles_vanilla: None,
-        work_experience:    "1..2".to_owned(),
-        work_locations:     vec!["Berlin".to_owned()],
-        work_authorization: "yes".to_owned(),
-        skills:             vec![],
-        summary:            "".to_owned(),
-        headline:           "".to_owned(),
-        job_titles:         vec![],
-        company_ids:        vec![],
-        batch_starts_at:    epoch_from_year!("2007"),
-        batch_ends_at:      epoch_from_year!("2020"),
-        added_to_batch_at:  epoch_from_year!("2011"),
-        weight:             6,
-        blocked_companies:  vec![]
+        id:                            3,
+        accepted:                      false,
+        desired_work_roles:            vec![],
+        desired_work_roles_vanilla:    None,
+        desired_work_roles_experience: vec![],
+        professional_experience:       "1..2".to_owned(),
+        work_locations:                vec!["Berlin".to_owned()],
+        work_authorization:            "yes".to_owned(),
+        skills:                        vec![],
+        summary:                       "".to_owned(),
+        headline:                      "".to_owned(),
+        work_experiences:              vec![],
+        contacted_company_ids:         vec![],
+        batch_starts_at:               epoch_from_year!("2007"),
+        batch_ends_at:                 epoch_from_year!("2020"),
+        added_to_batch_at:             epoch_from_year!("2011"),
+        weight:                        6,
+        blocked_companies:             vec![],
+        avatar_url:                    "https://secure.gravatar.com/avatar/a0b9ad63fb35d210a218c317e0a6284e.jpg?s=250".to_owned(),
+        salary_expectations:           None
       },
 
       Talent {
-        id:                 4,
-        accepted:           true,
-        work_roles:         vec!["Fullstack".to_owned(), "DevOps".to_owned()],
-        work_roles_vanilla: None,
-        work_experience:    "1..2".to_owned(),
-        work_locations:     vec!["Berlin".to_owned()],
-        work_authorization: "no".to_owned(),
-        skills:             vec!["ClojureScript".to_owned(), "C++".to_owned(), "React.js".to_owned()],
-        summary:            "ClojureScript right now, previously C++".to_owned(),
-        headline:           "Senior fullstack developer with sysadmin skills".to_owned(),
-        job_titles:         vec!["Backend Engineer".to_owned(), "Database Administrator".to_owned()],
-        company_ids:        vec![6],
-        batch_starts_at:    epoch_from_year!("2008"),
-        batch_ends_at:      epoch_from_year!("2020"),
-        added_to_batch_at:  epoch_from_year!("2011"),
-        weight:             0,
-        blocked_companies:  vec![]
+        id:                            4,
+        accepted:                      true,
+        desired_work_roles:            vec!["Fullstack".to_owned(), "DevOps".to_owned()],
+        desired_work_roles_vanilla:    None,
+        desired_work_roles_experience: vec!["2..3".to_owned(), "5".to_owned()],
+        professional_experience:       "1..2".to_owned(),
+        work_locations:                vec!["Berlin".to_owned()],
+        work_authorization:            "no".to_owned(),
+        skills:                        vec!["ClojureScript".to_owned(), "C++".to_owned(), "React.js".to_owned()],
+        summary:                       "ClojureScript right now, previously C++".to_owned(),
+        headline:                      "Senior fullstack developer with sysadmin skills".to_owned(),
+        work_experiences:              vec!["Backend Engineer".to_owned(), "Database Administrator".to_owned()],
+        contacted_company_ids:         vec![6],
+        batch_starts_at:               epoch_from_year!("2008"),
+        batch_ends_at:                 epoch_from_year!("2020"),
+        added_to_batch_at:             epoch_from_year!("2011"),
+        weight:                        0,
+        blocked_companies:             vec![],
+        avatar_url:                    "https://secure.gravatar.com/avatar/a0b9ad63fb35d210a218c317e0a6284e.jpg?s=250".to_owned(),
+        salary_expectations:           None
       },
 
       Talent {
-        id:                 5,
-        accepted:           true,
-        work_roles:         vec!["Fullstack".to_owned(), "DevOps".to_owned()],
-        work_roles_vanilla: None,
-        work_experience:    "1..2".to_owned(),
-        work_locations:     vec!["Berlin".to_owned()],
-        work_authorization: "yes".to_owned(),
-        skills:             vec!["JavaScript".to_owned(), "C++".to_owned(), "Ember.js".to_owned()],
-        summary:            "C++ and frontend dev. HTML, C++, JavaScript and C#. Did I say C++?".to_owned(),
-        headline:           "Amazing C developer".to_owned(),
-        job_titles:         vec![],
-        company_ids:        vec![6],
-        batch_starts_at:    epoch_from_year!("2008"),
-        batch_ends_at:      epoch_from_year!("2020"),
-        added_to_batch_at:  epoch_from_year!("2011"),
-        weight:             0,
-        blocked_companies:  vec![]
+        id:                            5,
+        accepted:                      true,
+        desired_work_roles:            vec!["Fullstack".to_owned(), "DevOps".to_owned()],
+        desired_work_roles_vanilla:    None,
+        desired_work_roles_experience: vec!["2..3".to_owned(), "5".to_owned()],
+        professional_experience:       "1..2".to_owned(),
+        work_locations:                vec!["Berlin".to_owned()],
+        work_authorization:            "yes".to_owned(),
+        skills:                        vec!["JavaScript".to_owned(), "C++".to_owned(), "Ember.js".to_owned()],
+        summary:                       "C++ and frontend dev. HTML, C++, JavaScript and C#. Did I say C++?".to_owned(),
+        headline:                      "Amazing C developer".to_owned(),
+        work_experiences:              vec![],
+        contacted_company_ids:         vec![6],
+        batch_starts_at:               epoch_from_year!("2008"),
+        batch_ends_at:                 epoch_from_year!("2020"),
+        added_to_batch_at:             epoch_from_year!("2011"),
+        weight:                        0,
+        blocked_companies:             vec![],
+        avatar_url:                    "https://secure.gravatar.com/avatar/a0b9ad63fb35d210a218c317e0a6284e.jpg?s=250".to_owned(),
+        salary_expectations:           None
       }
     ];
 
@@ -706,7 +728,7 @@ mod tests {
     // searching for work roles
     {
       let mut map = Map::new();
-      map.assign("work_roles[]", Value::String("Fullstack".into())).unwrap();
+      map.assign("desired_work_roles[]", Value::String("Fullstack".into())).unwrap();
 
       let results = Talent::search(&mut client, &*config.es.index, &map);
       assert_eq!(vec![4, 5], results.ids());
@@ -715,7 +737,7 @@ mod tests {
     // searching for work experience
     {
       let mut map = Map::new();
-      map.assign("work_experience[]", Value::String("8+".into())).unwrap();
+      map.assign("professional_experience[]", Value::String("8+".into())).unwrap();
 
       let results = Talent::search(&mut client, &*config.es.index, &map);
       assert_eq!(vec![2], results.ids());
@@ -772,7 +794,7 @@ mod tests {
       let mut map = Map::new();
       map.assign("keywords", Value::String("react.js".into())).unwrap();
       map.assign("work_locations[]", Value::String("Berlin".into())).unwrap();
-      map.assign("work_roles[]", Value::String("Fullstack".into())).unwrap();
+      map.assign("desired_work_roles[]", Value::String("Fullstack".into())).unwrap();
 
       let results = Talent::search(&mut client, &*config.es.index, &map);
       assert_eq!(vec![4], results.ids());
@@ -957,26 +979,29 @@ mod tests {
   fn test_json_decode() {
     let payload = "{
       \"id\":13,
-      \"work_roles\":[\"C/C++ Engineer\"],
-      \"work_languages\":[],
-      \"work_experience\":\"8+\",
+      \"desired_work_roles\":[\"C/C++ Engineer\"],
+      \"desired_work_roles_experience\":[\"2..4\"],
+      \"work_languages\":[\"C++\"],
+      \"professional_experience\":\"8+\",
       \"work_locations\":[\"Berlin\"],
       \"work_authorization\":\"yes\",
       \"skills\":[\"Rust\"],
-      \"summary\":\"\",
-      \"headline\":\"\",
-      \"job_titles\":[],
-      \"company_ids\":[],
+      \"summary\":\"Blabla\",
+      \"headline\":\"I see things, I do stuff\",
+      \"contacted_company_ids\":[1],
       \"accepted\":true,
       \"batch_starts_at\":\"2016-03-04T12:24:00+01:00\",
       \"batch_ends_at\":\"2016-04-11T12:24:00+02:00\",
       \"added_to_batch_at\":\"2016-03-11T12:24:37+01:00\",
       \"weight\":0,
-      \"blocked_companies\":[]
+      \"blocked_companies\":[99],
+      \"work_experiences\":[\"Frontend developer\", \"SysAdmin\"],
+      \"avatar_url\":\"https://secure.gravatar.com/avatar/47ac43379aa70038a9adc8ec88a1241d?s=250&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fa0b9ad63fb35d210a218c317e0a6284e%3Fs%3D250\",
+      \"salary_expectations\":\"30.000€ - 40.000€\"
     }".to_owned();
 
     let resource: Result<Talent, _> = serde_json::from_str(&payload);
     assert!(resource.is_ok());
-    assert_eq!(resource.unwrap().work_roles, vec!["C/C++ Engineer"]);
+    assert_eq!(resource.unwrap().desired_work_roles, vec!["C/C++ Engineer"]);
   }
 }

--- a/src/resources/talent.rs
+++ b/src/resources/talent.rs
@@ -50,6 +50,7 @@ pub struct FoundTalent {
   pub headline:                      String,
   pub avatar_url:                    String,
   pub work_locations:                Vec<String>,
+  pub current_location:              String,
   pub salary_expectations:           Option<String>,
   pub roles_experiences:             Vec<RolesExperience>
 }
@@ -85,6 +86,7 @@ impl From<Box<Talent>> for FoundTalent {
       headline:                      talent.headline.to_owned(),
       avatar_url:                    talent.avatar_url.to_owned(),
       work_locations:                talent.work_locations.to_owned(),
+      current_location:              talent.current_location.to_owned(),
       salary_expectations:           talent.salary_expectations.to_owned(),
       roles_experiences:             roles_experiences
     }
@@ -101,6 +103,7 @@ pub struct Talent {
   pub desired_work_roles_experience: Vec<String>, // experience in the desired work roles
   pub professional_experience:       String, // i.e. 2..6
   pub work_locations:                Vec<String>, // wants to work in
+  pub current_location:              String, // where the talent is based in
   pub work_authorization:            String, // yes/no/unsure (visa)
   pub skills:                        Vec<String>,
   pub summary:                       String,
@@ -397,6 +400,11 @@ impl Resource for Talent {
           "index" => "not_analyzed"
         },
 
+        "current_location" => hashmap! {
+          "type"  => "string",
+          "index" => "not_analyzed"
+        },
+
         "work_authorization" => hashmap! {
           "type"  => "string",
           "index" => "not_analyzed"
@@ -599,6 +607,7 @@ mod tests {
         desired_work_roles_experience: vec![],
         professional_experience:       "1..2".to_owned(),
         work_locations:                vec!["Berlin".to_owned()],
+        current_location:              "Berlin".to_owned(),
         work_authorization:            "yes".to_owned(),
         skills:                        vec!["Rust".to_owned(), "HTML5".to_owned(), "HTML".to_owned()],
         summary:                       "I'm a senior Rust developer and sometimes I do also HTML.".to_owned(),
@@ -622,6 +631,7 @@ mod tests {
         desired_work_roles_experience: vec![],
         professional_experience:       "8+".to_owned(),
         work_locations:                vec!["Rome".to_owned(),"Berlin".to_owned()],
+        current_location:              "Berlin".to_owned(),
         work_authorization:            "yes".to_owned(),
         skills:                        vec!["Rust".to_owned(), "HTML5".to_owned(), "Java".to_owned()],
         summary:                       "I'm a java dev with some tricks up my sleeves".to_owned(),
@@ -645,6 +655,7 @@ mod tests {
         desired_work_roles_experience: vec![],
         professional_experience:       "1..2".to_owned(),
         work_locations:                vec!["Berlin".to_owned()],
+        current_location:              "Berlin".to_owned(),
         work_authorization:            "yes".to_owned(),
         skills:                        vec![],
         summary:                       "".to_owned(),
@@ -668,6 +679,7 @@ mod tests {
         desired_work_roles_experience: vec!["2..3".to_owned(), "5".to_owned()],
         professional_experience:       "1..2".to_owned(),
         work_locations:                vec!["Berlin".to_owned()],
+        current_location:              "Berlin".to_owned(),
         work_authorization:            "no".to_owned(),
         skills:                        vec!["ClojureScript".to_owned(), "C++".to_owned(), "React.js".to_owned()],
         summary:                       "ClojureScript right now, previously C++".to_owned(),
@@ -691,6 +703,7 @@ mod tests {
         desired_work_roles_experience: vec!["2..3".to_owned(), "5".to_owned()],
         professional_experience:       "1..2".to_owned(),
         work_locations:                vec!["Berlin".to_owned()],
+        current_location:              "Berlin".to_owned(),
         work_authorization:            "yes".to_owned(),
         skills:                        vec!["JavaScript".to_owned(), "C++".to_owned(), "Ember.js".to_owned()],
         summary:                       "C++ and frontend dev. HTML, C++, JavaScript and C#. Did I say C++?".to_owned(),
@@ -1033,6 +1046,7 @@ mod tests {
       \"work_languages\":[\"C++\"],
       \"professional_experience\":\"8+\",
       \"work_locations\":[\"Berlin\"],
+      \"current_location\":\"Berlin\",
       \"work_authorization\":\"yes\",
       \"skills\":[\"Rust\"],
       \"summary\":\"Blabla\",


### PR DESCRIPTION
This PR changes the name of many fields of `Talent` and also adds three new ones: `desired_work_roles_experience`, `avatar_url` and `salary_expectations`.

Although these three last fields are not used to search anything, we need them to be returned to the client so that the honeypot's frontend can print the search results without having to call the backend, when we will be able to move the search totally on the frontend.

Unfortunately we can't use the ES multi-field right now (there's a [branch](https://github.com/honeypotio/searchspot/tree/multifield) for when it gets implemented in rs-es).
We can use multi-field to remove `desired_work_roles_vanilla` (we'll call `desired_work_roles.vanilla` instead) and also join `desired_work_roles` to `desired_work_roles_experience` (`desired_work_roles.role` / `desired_work_roles.experience`).