### PR TITLE
server: share client through the handlers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ iron         = "0.5"
 router       = "0.5"
 logger       = "0.3"
 params       = "0.6"
+persistent   = "0.3"
 
 lazy_static  = "0.2"
 maplit       = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ extern crate iron;
 extern crate logger as http_logger;
 extern crate router;
 extern crate params;
+extern crate persistent;
 
 extern crate rs_es;
 extern crate toml;

--- a/src/server.rs
+++ b/src/server.rs
@@ -6,6 +6,9 @@ use rs_es::Client;
 use iron::prelude::*;
 use iron::{status, Handler, Headers};
 use iron::mime::Mime;
+use iron::typemap::Key;
+
+use persistent::Write;
 
 use http_logger::Logger as HTTPLogger;
 
@@ -23,7 +26,11 @@ use std::collections::HashMap;
 use std::env;
 use std::io::Read;
 use std::marker::PhantomData;
-use std::sync::{Arc, Mutex};
+
+#[derive(Copy, Clone)]
+pub struct SharedClient;
+
+impl Key for SharedClient { type Value = Client; }
 
 macro_rules! try_or_422 {
   ($expr:expr) => (match $expr {
@@ -92,15 +99,13 @@ authorization!(WritableEndpoint, write);
 
 pub struct SearchableHandler<R> {
   config:   Config,
-  client:   Arc<Mutex<Client>>,
   resource: PhantomData<R>
 }
 
 impl<R: Resource> SearchableHandler<R> {
-  fn new(client: Arc<Mutex<Client>>, config: Config) -> Self {
+  fn new(config: Config) -> Self {
     SearchableHandler::<R> {
       resource: PhantomData,
-      client:   client,
       config:   config
     }
   }
@@ -114,9 +119,10 @@ impl<R: Resource> Handler for SearchableHandler<R> {
       unauthorized!();
     }
 
+    let client = req.get::<Write<SharedClient>>().unwrap();
     let params = try_or_422!(req.get_ref::<Params>());
 
-    let response = R::search(&mut self.client.lock().unwrap(), &*self.config.es.index, params);
+    let response = R::search(&mut client.lock().unwrap(), &*self.config.es.index, params);
 
     let content_type = "application/json".parse::<Mime>().unwrap();
     Ok(Response::with(
@@ -127,15 +133,13 @@ impl<R: Resource> Handler for SearchableHandler<R> {
 
 pub struct IndexableHandler<R> {
   config:   Config,
-  client:   Arc<Mutex<Client>>,
   resource: PhantomData<R>
 }
 
 impl<R: Resource> IndexableHandler<R> {
-  fn new(client: Arc<Mutex<Client>>, config: Config) -> Self {
+  fn new(config: Config) -> Self {
     IndexableHandler::<R> {
       resource: PhantomData,
-      client:   client,
       config:   config
     }
   }
@@ -153,7 +157,8 @@ impl<R: Resource> Handler for IndexableHandler<R> {
     req.body.read_to_string(&mut payload).unwrap();
 
     let resources: Vec<R> = try_or_422!(serde_json::from_str(&payload));
-    try_or_422!(R::index(&mut self.client.lock().unwrap(), &*self.config.es.index, resources));
+    let client = req.get::<Write<SharedClient>>().unwrap();
+    try_or_422!(R::index(&mut client.lock().unwrap(), &*self.config.es.index, resources));
 
     Ok(Response::with(status::Created))
   }
@@ -161,15 +166,13 @@ impl<R: Resource> Handler for IndexableHandler<R> {
 
 pub struct DeletableHandler<R> {
   config:   Config,
-  client:   Arc<Mutex<Client>>,
   resource: PhantomData<R>
 }
 
 impl<R: Resource> DeletableHandler<R> {
-  fn new(client: Arc<Mutex<Client>>, config: Config) -> Self {
+  fn new(config: Config) -> Self {
     DeletableHandler::<R> {
       resource: PhantomData,
-      client:   client,
       config:   config
     }
   }
@@ -183,11 +186,14 @@ impl<R: Resource> Handler for DeletableHandler<R> {
       unauthorized!();
     }
 
+    let     client = req.get::<Write<SharedClient>>().unwrap();
+    let mut client = client.lock().unwrap();
+
     let ref id = try_or_422!(req.extensions.get::<Router>().unwrap()
                                                            .find("id")
                                                            .ok_or("DELETE#:id not found"));
 
-    match R::delete(&mut self.client.lock().unwrap(), id, &*self.config.es.index) {
+    match R::delete(&mut client, id, &*self.config.es.index) {
       Ok(_)  => Ok(Response::with(status::NoContent)),
       Err(e) => {
         let error_message = e.to_string();
@@ -204,15 +210,13 @@ impl<R: Resource> Handler for DeletableHandler<R> {
 
 pub struct ResettableHandler<R> {
   config:   Config,
-  client:   Arc<Mutex<Client>>,
   resource: PhantomData<R>
 }
 
 impl<R: Resource> ResettableHandler<R> {
-  fn new(client: Arc<Mutex<Client>>, config: Config) -> Self {
+  fn new(config: Config) -> Self {
     ResettableHandler::<R> {
       resource: PhantomData,
-      client:   client,
       config:   config
     }
   }
@@ -226,7 +230,9 @@ impl<R: Resource> Handler for ResettableHandler<R> {
       unauthorized!();
     }
 
-    match R::reset_index(&mut self.client.lock().unwrap(), &*self.config.es.index) {
+    let     client = req.get::<Write<SharedClient>>().unwrap();
+    let mut client = client.lock().unwrap();
+    match R::reset_index(&mut client, &*self.config.es.index) {
       Ok(_)  => Ok(Response::with(status::NoContent)),
       Err(e) => {
         let error_message = e.to_string();
@@ -264,21 +270,23 @@ impl<R: Resource> Server<R> {
                                          self.config.es,
                                          self.config.http);
 
-    let client = Arc::new(Mutex::new(Client::new(&*self.config.to_owned().es.url).unwrap()));
-
     let mut router = Router::new();
-    router.get(&self.endpoint,    SearchableHandler::<R>::new(client.clone(), self.config.to_owned()), "search");
-    router.post(&self.endpoint,   IndexableHandler::<R>::new(client.clone(), self.config.to_owned()),  "index");
-    router.delete(&self.endpoint, ResettableHandler::<R>::new(client.clone(), self.config.to_owned()), "reset");
+    router.get(&self.endpoint,    SearchableHandler::<R>::new(self.config.to_owned()), "search");
+    router.post(&self.endpoint,   IndexableHandler::<R>::new(self.config.to_owned()),  "index");
+    router.delete(&self.endpoint, ResettableHandler::<R>::new(self.config.to_owned()), "reset");
 
     let deletable_endpoint = format!("{}/:id", self.endpoint);
-    router.delete(deletable_endpoint, DeletableHandler::<R>::new(client.clone(), self.config.to_owned()), "delete");
+    router.delete(deletable_endpoint, DeletableHandler::<R>::new(self.config.to_owned()), "delete");
+
+    let client = Client::new(&*self.config.to_owned().es.url).unwrap();
 
     match env::var("DYNO") { // for some reasons, chain::link makes heroku crash
       Ok(_)  => Iron::new(router).http(&*host),
       Err(_) => {
         let mut chain = Chain::new(router);
         chain.link(HTTPLogger::new(None));
+        chain.link(Write::<SharedClient>::both(client));
+
         Iron::new(chain).http(&*host)
       }
     }.unwrap();

--- a/src/server.rs
+++ b/src/server.rs
@@ -280,16 +280,11 @@ impl<R: Resource> Server<R> {
 
     let client = Client::new(&*self.config.to_owned().es.url).unwrap();
 
-    match env::var("DYNO") { // for some reasons, chain::link makes heroku crash
-      Ok(_)  => Iron::new(router).http(&*host),
-      Err(_) => {
-        let mut chain = Chain::new(router);
-        chain.link(HTTPLogger::new(None));
-        chain.link(Write::<SharedClient>::both(client));
+    let mut chain = Chain::new(router);
+    chain.link(HTTPLogger::new(None));
+    chain.link(Write::<SharedClient>::both(client));
 
-        Iron::new(chain).http(&*host)
-      }
-    }.unwrap();
+    Iron::new(chain).http(&*host).unwrap();
   }
 }
 


### PR DESCRIPTION
Thanks to `Arc<Mutex<T>>`, we can share copy to the reference of an object to multiple threads safely (cloning an Arc doesn't actually create a new object. Instad of cloning the original, it produces a new reference to it, garbage collected by the Arc itself, being a reference-counter type).

More simplicity aside, with this we got an increment of req/s of ~13%.