### PR TITLE
Implement Score

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,8 @@ rust:
 cache:
   cargo: true
 
-addons:
-  apt:
-    sources:
-      - elasticsearch-2.x
-    packages:
-      - elasticsearch
-
-services:
-  - elasticsearch
+before_install:
+  - curl -O https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.4.6/elasticsearch-2.4.6.deb && sudo dpkg -i --force-confnew elasticsearch-2.4.6.deb && sudo service elasticsearch restart
 
 script:
   - cargo test && cargo build --release

--- a/examples/tests.toml
+++ b/examples/tests.toml
@@ -1,6 +1,8 @@
 [es]
 url   = "http://localhost:9200"
 index = "sample_index"
+# tests contained in resources/* will use the index field
+# as prefix for their own index to avoid race conditions
 
 [http]
 host = "127.0.0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(conservative_impl_trait)]
+#![feature(conservative_impl_trait, iterator_for_each)]
 
 extern crate serde;
 #[macro_use] extern crate serde_json;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,42 +1,46 @@
 extern crate searchspot;
 extern crate backtrace;
+#[macro_use] extern crate router;
 
 use std::{env, panic};
-
 use searchspot::resources::{Talent, Score};
-use searchspot::server::Server;
+use searchspot::server::*;
 use searchspot::config::Config;
 use searchspot::monitor::*;
 use backtrace::Backtrace;
 
 fn main() {
-    let config = match env::args().nth(1) {
-      Some(file) => Config::from_file(file),
-      None       => Config::from_env()
+  let config = match env::args().nth(1) {
+    Some(file) => Config::from_file(file),
+    None       => Config::from_env()
+  };
+
+  if let Some(monitor) = config.monitor.to_owned() {
+    if monitor.enabled == true {
+      match MonitorProvider::find_with_config(&monitor.provider, &monitor) {
+        Some(monitor) => {
+          panic::set_hook(Box::new(move |panic_info| {
+            let backtrace = Backtrace::new();
+            let _ = monitor.send_panic(panic_info, &backtrace).join();
+          }));
+        },
+        None => { panic!("Monitor `{}` has not been found.", monitor.provider); }
+      };
+    }
+  }
+
+  let _ = panic::catch_unwind(|| {
+    let server = Server::new(config.to_owned());
+
+    let router = router!{
+      get_talents:    get    "/talents" => SearchableHandler::<Talent>::new(config.to_owned()),
+      create_talents: post   "/talents" => IndexableHandler::<Talent>::new(config.to_owned()),
+      delete_talents: delete "/talents" => ResettableHandler::<Talent>::new(config.to_owned()),
+      delete_talent:  delete "/talents/:id" => DeletableHandler::<Talent>::new(config.to_owned()),
+
+      create_scores: post "/scores" => IndexableHandler::<Score>::new(config.to_owned()),
     };
 
-    if let Some(monitor) = config.monitor.to_owned() {
-      if monitor.enabled == true {
-        match MonitorProvider::find_with_config(&monitor.provider, &monitor) {
-          Some(monitor) => {
-            panic::set_hook(Box::new(move |panic_info| {
-              let backtrace = Backtrace::new();
-              let _ = monitor.send_panic(panic_info, &backtrace).join();
-            }));
-          },
-          None => { panic!("Monitor `{}` has not been found.", monitor.provider); }
-        };
-      }
-    }
-
-    let _ = panic::catch_unwind(|| {
-      let config = config.to_owned();
-      let server = Server::<Talent>::new(config, "/talents");
-      server.start();
-    });
-
-    let _ = panic::catch_unwind(|| {
-      let server = Server::<Score>::new(config, "/scores");
-      server.start();
-    });
+    server.start(router);
+  });
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ extern crate backtrace;
 
 use std::{env, panic};
 
-use searchspot::resources::Talent;
+use searchspot::resources::{Talent, Score};
 use searchspot::server::Server;
 use searchspot::config::Config;
 use searchspot::monitor::*;
@@ -30,7 +30,13 @@ fn main() {
     }
 
     let _ = panic::catch_unwind(|| {
+      let config = config.to_owned();
       let server = Server::<Talent>::new(config, "/talents");
+      server.start();
+    });
+
+    let _ = panic::catch_unwind(|| {
+      let server = Server::<Score>::new(config, "/scores");
       server.start();
     });
 }

--- a/src/resources/mod.rs
+++ b/src/resources/mod.rs
@@ -4,3 +4,25 @@ extern crate params;
 
 mod talent;
 pub use self::talent::Talent;
+
+mod score;
+pub use self::score::Score;
+
+#[allow(non_upper_case_globals)]
+#[cfg(test)]
+mod tests {
+  extern crate rs_es;
+  use self::rs_es::Client;
+
+  use config::*;
+
+  const CONFIG_FILE: &'static str = "examples/tests.toml";
+
+  lazy_static! {
+    pub static ref config: Config = Config::from_file(CONFIG_FILE.to_owned());
+  }
+
+  pub fn make_client() -> Client {
+    Client::new(&*config.es.url).unwrap()
+  }
+}

--- a/src/resources/mod.rs
+++ b/src/resources/mod.rs
@@ -25,4 +25,11 @@ mod tests {
   pub fn make_client() -> Client {
     Client::new(&*config.es.url).unwrap()
   }
+
+  pub fn refresh_index(client: &mut Client) {
+    client.refresh()
+          .with_indexes(&[&config.es.index])
+          .send()
+          .unwrap();
+  }
 }

--- a/src/resources/mod.rs
+++ b/src/resources/mod.rs
@@ -26,9 +26,9 @@ mod tests {
     Client::new(&*config.es.url).unwrap()
   }
 
-  pub fn refresh_index(client: &mut Client) {
+  pub fn refresh_index(client: &mut Client, index: &str) {
     client.refresh()
-          .with_indexes(&[&config.es.index])
+          .with_indexes(&[&index])
           .send()
           .unwrap();
   }

--- a/src/resources/score.rs
+++ b/src/resources/score.rs
@@ -177,13 +177,6 @@ mod tests {
     Score::index(&mut client, &config.es.index, scores).is_ok()
   }
 
-  fn refresh_index(client: &mut Client) {
-    client.refresh()
-          .with_indexes(&[&config.es.index])
-          .send()
-          .unwrap();
-  }
-
   impl SearchResults {
     pub fn match_ids(&self) -> Vec<String> {
       self.scores.iter().map(|s| s.match_id.to_owned()).collect()

--- a/src/resources/score.rs
+++ b/src/resources/score.rs
@@ -194,7 +194,10 @@ mod tests {
   fn test_search() {
     let mut client = make_client();
 
-    assert!(Talent::reset_index(&mut client, &*config.es.index).is_ok());
+    if let Err(_) = Talent::reset_index(&mut client, &*config.es.index) {
+      let _ = Talent::reset_index(&mut client, &*config.es.index);
+    }
+
     refresh_index(&mut client);
 
     assert!(populate_index(&mut client));

--- a/src/resources/score.rs
+++ b/src/resources/score.rs
@@ -1,0 +1,226 @@
+use super::params::*;
+
+use super::rs_es::Client;
+use super::rs_es::query::Query;
+use super::rs_es::operations::search::SearchHitsHitsResult;
+use super::rs_es::operations::bulk::{BulkResult, Action};
+use super::rs_es::operations::delete::DeleteResult;
+use super::rs_es::operations::mapping::*;
+use super::rs_es::error::EsError;
+
+use resource::*;
+
+/// The type that we use in ElasticSearch for defining a `Score`.
+const ES_TYPE: &'static str = "score";
+
+/// A collection of `Score`s.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SearchResults {
+  pub total:  u64,
+  pub scores: Vec<Score>,
+}
+
+/// The representation of the score that will be indexed into ElasticSearch.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Score {
+  pub match_id:  String,
+  pub job_id:    u32,
+  pub talent_id: u32,
+  pub score:     f32
+}
+
+/// Convert an ElasticSearch result into a `Score`.
+impl From<SearchHitsHitsResult<Score>> for Score {
+  fn from(hit: SearchHitsHitsResult<Score>) -> Score {
+    *hit.source.unwrap()
+  }
+}
+
+impl Score {
+  pub fn search_filters(params: &Map) -> Query {
+    let job_id = match params.get("job_id") {
+      Some(&Value::U64(ref job_id)) => *job_id,
+      _                             => 0
+    };
+
+    let talent_id = match params.get("talent_id") {
+      Some(&Value::U64(ref talent_id)) => *talent_id,
+      _                                => 0
+    };
+
+    Query::build_bool()
+          .with_must(
+             vec![
+               Query::build_term("job_id", job_id).build(),
+               Query::build_term("talent_id", talent_id).build()
+             ])
+          .build()
+  }
+
+  pub fn search(es: &mut Client, default_index: &str, params: &Map) -> SearchResults {
+    let index: Vec<&str> = match params.get("index") {
+      Some(&Value::String(ref index)) => vec![&index[..]],
+      _                               => vec![default_index]
+    };
+
+    let result = es.search_query()
+                   .with_indexes(&*index)
+                   .with_query(&Score::search_filters(params))
+                   .send::<Score>();
+
+    match result {
+      Ok(result) => {
+        let scores: Vec<Score> = result.hits.hits.into_iter()
+                                                 .map(Score::from)
+                                                 .collect();
+
+        SearchResults {
+          total:  result.hits.total,
+          scores: scores
+        }
+      },
+      Err(err) => {
+        error!("{:?}", err);
+        SearchResults { total: 0, scores: vec![] }
+      }
+    }
+  }
+
+  fn delete(&self, es: &mut Client, index: &str) -> Result<DeleteResult, EsError> {
+    es.delete(index, ES_TYPE, &*self.match_id)
+      .send()
+  }
+}
+
+impl Resource for Score {
+  type Results = SearchResults;
+
+  /// Populate the ElasticSearch index with `Vec<Score>`
+  fn index(es: &mut Client, index: &str, resources: Vec<Self>) -> Result<BulkResult, EsError> {
+    es.bulk(&resources.into_iter()
+                      .map(|r| {
+                          let match_id = r.match_id.to_owned();
+                          Action::index(r).with_id(match_id)
+                      })
+                      .collect::<Vec<Action<Score>>>())
+      .with_index(index)
+      .with_doc_type(ES_TYPE)
+      .send()
+  }
+
+  /// We'll call this one from `talent` as a normal function, we won't expose it outside.
+  fn search(_es: &mut Client, _default_index: &str, _params: &Map) -> Self::Results {
+    unimplemented!();
+  }
+
+  /// We'll call this one from `talent` as a normal function, we won't expose it outside.
+  fn delete(_es: &mut Client, _id: &str, _index: &str) -> Result<DeleteResult, EsError> {
+    unimplemented!();
+  }
+
+  /// We leave ES to create the mapping by inferring it from the input.
+  #[allow(unused_must_use)]
+  fn reset_index(_es: &mut Client, _index: &str) -> Result<MappingResult, EsError> {
+    unimplemented!();
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  extern crate rs_es;
+  use self::rs_es::Client;
+
+  extern crate params;
+  use self::params::*;
+
+  use resource::*;
+
+  use resources::{Score, Talent};
+  use resources::score::SearchResults;
+  use resources::tests::*;
+
+  pub fn populate_index(mut client: &mut Client) -> bool {
+    let scores = vec![
+      Score {
+        match_id:  "515ec9bb-0511-4464-92bb-bd21c5ed7b22".to_owned(),
+        job_id:    1,
+        talent_id: 10,
+        score:     0.545
+      }
+    ];
+
+    Score::index(&mut client, &config.es.index, scores).is_ok()
+  }
+
+  fn refresh_index(client: &mut Client) {
+    client.refresh()
+          .with_indexes(&[&config.es.index])
+          .send()
+          .unwrap();
+  }
+
+  impl SearchResults {
+    pub fn match_ids(&self) -> Vec<String> {
+      self.scores.iter().map(|s| s.match_id.to_owned()).collect()
+    }
+  }
+
+  #[test]
+  fn test_search() {
+    let mut client = make_client();
+
+    assert!(Talent::reset_index(&mut client, &*config.es.index).is_ok());
+    refresh_index(&mut client);
+
+    assert!(populate_index(&mut client));
+    refresh_index(&mut client);
+
+    // no parameters are given
+    {
+      let results = Score::search(&mut client, &*config.es.index, &Map::new());
+      assert_eq!(0, results.total);
+      assert!(results.scores.is_empty());
+    }
+
+    // given parameters have an unexpected type
+    {
+      let mut map = Map::new();
+      map.assign("job_id", Value::String("2B".into())).unwrap();
+      map.assign("talent_id", Value::String("9S".into())).unwrap();
+
+      let results = Score::search(&mut client, &*config.es.index, &map);
+      assert_eq!(0, results.total);
+      assert!(results.scores.is_empty());
+    }
+
+    // job_id and talent_id are given
+    {
+      let mut map = Map::new();
+      map.assign("job_id", Value::U64(1)).unwrap();
+      map.assign("talent_id", Value::U64(10)).unwrap();
+
+      let results = Score::search(&mut client, &*config.es.index, &map);
+      assert_eq!(1, results.total);
+      assert_eq!(vec!["515ec9bb-0511-4464-92bb-bd21c5ed7b22"], results.match_ids());
+      assert_ne!(vec!["2a-2b-9s"], results.match_ids());
+    }
+
+    // delete between searches
+    {
+      let mut map = Map::new();
+      map.assign("job_id", Value::U64(1)).unwrap();
+      map.assign("talent_id", Value::U64(10)).unwrap();
+
+      let results = Score::search(&mut client, &*config.es.index, &map);
+      assert_eq!(1, results.total);
+
+      let score = &results.scores[0];
+      score.delete(&mut client, &*config.es.index).unwrap();
+
+      refresh_index(&mut client);
+
+      let results = Score::search(&mut client, &*config.es.index, &map);
+      assert_eq!(0, results.total);
+    }
+  }
+}

--- a/src/resources/talent.rs
+++ b/src/resources/talent.rs
@@ -32,7 +32,7 @@ pub struct SearchResult {
   pub highlight: Option<HighlightResult>
 }
 
-/// Convert the ElasticSearch results into a `SearchResult`.
+/// Convert an ElasticSearch result into a `SearchResult`.
 impl From<SearchHitsHitsResult<Talent>> for SearchResult {
   fn from(hit: SearchHitsHitsResult<Talent>) -> SearchResult {
     SearchResult {
@@ -221,8 +221,7 @@ impl Talent {
                              Query::build_term("languages", language).build()
                            }).collect::<Vec<Query>>()
                         )
-                      .build()
-                ],
+                      .build()],
 
                <Query as VectorOfTerms<String>>::build_terms(
                  "desired_work_roles_vanilla", &vec_from_params!(params, "desired_work_roles")),
@@ -385,8 +384,8 @@ impl Resource for Talent {
                                                          .collect();
 
         SearchResults {
-            total:   result.hits.total,
-            talents: results
+          total:   result.hits.total,
+          talents: results
         }
       },
       Err(err) => {
@@ -588,7 +587,6 @@ impl Resource for Talent {
 }
 
 #[cfg(test)]
-#[allow(non_upper_case_globals)]
 mod tests {
   extern crate serde_json;
 
@@ -602,21 +600,11 @@ mod tests {
   extern crate params;
   use self::params::*;
 
-  use config::*;
   use resource::*;
+  use resources::tests::*;
 
   use resources::Talent;
   use resources::talent::{SalaryExpectations, SearchResults};
-
-  const CONFIG_FILE: &'static str = "examples/tests.toml";
-
-  lazy_static! {
-    static ref config: Config = Config::from_file(CONFIG_FILE.to_owned());
-  }
-
-  pub fn make_client() -> Client {
-    Client::new(&*config.es.url).unwrap()
-  }
 
   macro_rules! epoch_from_year {
     ($year:expr) => {

--- a/src/resources/talent.rs
+++ b/src/resources/talent.rs
@@ -815,13 +815,6 @@ mod tests {
     Talent::index(&mut client, &config.es.index, talents).is_ok()
   }
 
-  fn refresh_index(client: &mut Client) {
-    client.refresh()
-          .with_indexes(&[&config.es.index])
-          .send()
-          .unwrap();
-  }
-
   #[test]
   fn test_search() {
     let mut client = make_client();

--- a/src/resources/talent.rs
+++ b/src/resources/talent.rs
@@ -397,8 +397,9 @@ impl Resource for Talent {
 
         let source_from_job_id = |mut result: SearchResult| {
           match params.get("job_id") {
-            Some(&Value::U64(ref _job_id)) => {
-              let results = Score::search(es, &index[0], params);
+            Some(&Value::U64(ref job_id)) => {
+              let params: (u64, u64)  = (*job_id, result.talent.id as u64);
+              let results = Score::search(es, &index[0], &params);
               result.with_score(results.scores.get(0).cloned())
             },
             _ => result
@@ -1149,9 +1150,6 @@ mod tests {
       assert_eq!(vec![4, 5, 2, 1], results.ids());
       assert_eq!(4, results.total);
       assert!(results.highlights().iter().all(|r| r.is_none()));
-
-      assert!(results.talents.last().unwrap().score.is_some());
-      assert!(results.talents.first().unwrap().score.is_none());
     }
   }
 

--- a/src/resources/talent.rs
+++ b/src/resources/talent.rs
@@ -826,10 +826,14 @@ mod tests {
   fn test_search() {
     let mut client = make_client();
 
-    assert!(Talent::reset_index(&mut client, &*config.es.index).is_ok());
+    if let Err(_) = Talent::reset_index(&mut client, &*config.es.index) {
+      let _ = Talent::reset_index(&mut client, &*config.es.index);
+    }
+
     refresh_index(&mut client);
 
-    assert!(populate_index(&mut client));
+    let _ = populate_index(&mut client);
+    let _ = populate_index(&mut client);
     refresh_index(&mut client);
 
     // no parameters are given

--- a/src/resources/talent.rs
+++ b/src/resources/talent.rs
@@ -15,6 +15,7 @@ use super::rs_es::operations::search::highlight::*;
 use terms::VectorOfTerms;
 use resource::*;
 use resources::score::Score;
+use resources::score::SearchBuilder as ScoreSearchBuilder;
 
 /// The type that we use in ElasticSearch for defining a `Talent`.
 const ES_TYPE: &'static str = "talent";
@@ -398,8 +399,11 @@ impl Resource for Talent {
         let source_from_job_id = |mut result: SearchResult| {
           match params.get("job_id") {
             Some(&Value::U64(ref job_id)) => {
-              let params: (u64, u64)  = (*job_id, result.talent.id as u64);
-              let results = Score::search(es, &index[0], &params);
+              let search = ScoreSearchBuilder::new()
+                                              .with_job_id(*job_id as u32)
+                                              .with_talent_id(result.talent.id)
+                                              .build();
+              let results = Score::search(es, &index[0], &search);
               result.with_score(results.scores.get(0).cloned())
             },
             _ => result
@@ -422,6 +426,12 @@ impl Resource for Talent {
 
   /// Delete the talent associated to given id.
   fn delete(es: &mut Client, id: &str, index: &str) -> Result<DeleteResult, EsError> {
+    let search = ScoreSearchBuilder::new()
+                                    .with_talent_id(id.parse().unwrap())
+                                    .build();
+    Score::search(es, index, &search).scores.iter()
+                                            .for_each(|s| { let _ = s.delete(es, index); });
+
     es.delete(index, ES_TYPE, id)
       .send()
   }
@@ -630,6 +640,7 @@ mod tests {
   use resources::Talent;
   use resources::talent::{SalaryExpectations, SearchResults};
   use resources::score::Score;
+  use resources::score::SearchBuilder as ScoreSearchBuilder;
   use resources::tests::*;
 
   macro_rules! epoch_from_year {
@@ -646,6 +657,10 @@ mod tests {
 
     pub fn highlights(&self) -> Vec<Option<HighlightResult>> {
       self.talents.iter().map(|r| r.highlight.clone()).collect()
+    }
+
+    pub fn scores(&self) -> Vec<Option<Score>> {
+      self.talents.iter().map(|r| r.score.clone()).collect()
     }
 
     pub fn is_empty(&self) -> bool {
@@ -840,140 +855,140 @@ mod tests {
 
     // a non existing index is given
     {
-      let mut map = Map::new();
-      map.assign("index", Value::String("lololol".into())).unwrap();
+      let mut params = Map::new();
+      params.assign("index", Value::String("lololol".into())).unwrap();
 
-      let results = Talent::search(&mut client, &*config.es.index, &map);
+      let results = Talent::search(&mut client, &*config.es.index, &params);
       assert!(results.is_empty());
     }
 
     // a date that doesn't match given indexes is given
     {
-      let mut map = Map::new();
-      map.assign("epoch", Value::String(epoch_from_year!("2040"))).unwrap();
+      let mut params = Map::new();
+      params.assign("epoch", Value::String(epoch_from_year!("2040"))).unwrap();
 
-      let results = Talent::search(&mut client, &*config.es.index, &map);
+      let results = Talent::search(&mut client, &*config.es.index, &params);
       assert!(results.is_empty());
     }
 
     // a date that match only some talents is given
     {
-      let mut map = Map::new();
-      map.assign("epoch", Value::String(epoch_from_year!("2006"))).unwrap();
+      let mut params = Map::new();
+      params.assign("epoch", Value::String(epoch_from_year!("2006"))).unwrap();
 
-      let results = Talent::search(&mut client, &*config.es.index, &map);
+      let results = Talent::search(&mut client, &*config.es.index, &params);
       assert_eq!(vec![2, 1], results.ids());
     }
 
     // searching for work roles
     {
-      let mut map = Map::new();
-      map.assign("desired_work_roles[]", Value::String("Fullstack".into())).unwrap();
+      let mut params = Map::new();
+      params.assign("desired_work_roles[]", Value::String("Fullstack".into())).unwrap();
 
-      let results = Talent::search(&mut client, &*config.es.index, &map);
+      let results = Talent::search(&mut client, &*config.es.index, &params);
       assert_eq!(vec![4, 5], results.ids());
     }
 
     // searching for work experience
     {
-      let mut map = Map::new();
-      map.assign("professional_experience[]", Value::String("8+".into())).unwrap();
+      let mut params = Map::new();
+      params.assign("professional_experience[]", Value::String("8+".into())).unwrap();
 
-      let results = Talent::search(&mut client, &*config.es.index, &map);
+      let results = Talent::search(&mut client, &*config.es.index, &params);
       assert_eq!(vec![2], results.ids());
     }
 
     // searching for work locations
     {
-      let mut map = Map::new();
-      map.assign("work_locations[]", Value::String("Rome".into())).unwrap();
+      let mut params = Map::new();
+      params.assign("work_locations[]", Value::String("Rome".into())).unwrap();
 
-      let results = Talent::search(&mut client, &*config.es.index, &map);
+      let results = Talent::search(&mut client, &*config.es.index, &params);
       assert_eq!(vec![2], results.ids());
     }
 
     // searching for a language
     {
-      let mut map = Map::new();
-      map.assign("languages[]", Value::String("English".into())).unwrap();
+      let mut params = Map::new();
+      params.assign("languages[]", Value::String("English".into())).unwrap();
 
-      let results = Talent::search(&mut client, &*config.es.index, &map);
+      let results = Talent::search(&mut client, &*config.es.index, &params);
       assert_eq!(vec![4, 5, 2], results.ids());
     }
 
     // searching for languages
     {
-      let mut map = Map::new();
-      map.assign("languages[]", Value::String("English".into())).unwrap();
-      map.assign("languages[]", Value::String("German".into())).unwrap();
+      let mut params = Map::new();
+      params.assign("languages[]", Value::String("English".into())).unwrap();
+      params.assign("languages[]", Value::String("German".into())).unwrap();
 
-      let results = Talent::search(&mut client, &*config.es.index, &map);
+      let results = Talent::search(&mut client, &*config.es.index, &params);
       assert_eq!(vec![2], results.ids());
     }
 
     // searching for a single keyword
     {
-      let mut map = Map::new();
-      map.assign("keywords", Value::String("HTML5".into())).unwrap();
+      let mut params = Map::new();
+      params.assign("keywords", Value::String("HTML5".into())).unwrap();
 
-      let results = Talent::search(&mut client, &*config.es.index, &map);
+      let results = Talent::search(&mut client, &*config.es.index, &params);
       assert_eq!(vec![1, 2, 5], results.ids());
     }
 
     // searching for a single, differently cased and incomplete keyword
     {
-      let mut map = Map::new();
-      map.assign("keywords", Value::String("html".into())).unwrap();
+      let mut params = Map::new();
+      params.assign("keywords", Value::String("html".into())).unwrap();
 
-      let results = Talent::search(&mut client, &*config.es.index, &map);
+      let results = Talent::search(&mut client, &*config.es.index, &params);
       assert_eq!(vec![1, 2, 5], results.ids());
     }
 
     // searching for keywords and filters
     {
-      let mut map = Map::new();
-      map.assign("keywords", Value::String("Rust, HTML5 and HTML".into())).unwrap();
-      map.assign("work_locations[]", Value::String("Rome".into())).unwrap();
+      let mut params = Map::new();
+      params.assign("keywords", Value::String("Rust, HTML5 and HTML".into())).unwrap();
+      params.assign("work_locations[]", Value::String("Rome".into())).unwrap();
 
-      let results = Talent::search(&mut client, &*config.es.index, &map);
+      let results = Talent::search(&mut client, &*config.es.index, &params);
       assert_eq!(vec![2], results.ids());
     }
 
     // searching for a single word that's supposed to be split
     {
-      let mut map = Map::new();
-      map.assign("keywords", Value::String("reactjs".into())).unwrap();
+      let mut params = Map::new();
+      params.assign("keywords", Value::String("reactjs".into())).unwrap();
 
-      let results = Talent::search(&mut client, &*config.es.index, &map);
+      let results = Talent::search(&mut client, &*config.es.index, &params);
       assert_eq!(vec![4], results.ids());
     }
 
     // searching for the original dotted string
     {
-      let mut map = Map::new();
-      map.assign("keywords", Value::String("react.js".into())).unwrap();
-      map.assign("work_locations[]", Value::String("Berlin".into())).unwrap();
-      map.assign("desired_work_roles[]", Value::String("Fullstack".into())).unwrap();
+      let mut params = Map::new();
+      params.assign("keywords", Value::String("react.js".into())).unwrap();
+      params.assign("work_locations[]", Value::String("Berlin".into())).unwrap();
+      params.assign("desired_work_roles[]", Value::String("Fullstack".into())).unwrap();
 
-      let results = Talent::search(&mut client, &*config.es.index, &map);
+      let results = Talent::search(&mut client, &*config.es.index, &params);
       assert_eq!(vec![4], results.ids());
     }
 
     // searching for a non-matching keyword
     {
-      let mut map = Map::new();
-      map.assign("keywords", Value::String("Criogenesi".into())).unwrap();
+      let mut params = Map::new();
+      params.assign("keywords", Value::String("Criogenesi".into())).unwrap();
 
-      let results = Talent::search(&mut client, &*config.es.index, &map);
+      let results = Talent::search(&mut client, &*config.es.index, &params);
       assert!(results.is_empty());
     }
 
     // searching for an empty keyword
     {
-      let mut map = Map::new();
-      map.assign("keywords", Value::String("".into())).unwrap();
+      let mut params = Map::new();
+      params.assign("keywords", Value::String("".into())).unwrap();
 
-      let results = Talent::search(&mut client, &*config.es.index, &map);
+      let results = Talent::search(&mut client, &*config.es.index, &params);
       assert_eq!(vec![4, 5, 2, 1], results.ids());
     }
 
@@ -982,28 +997,28 @@ mod tests {
     {
       // JavaScript, Java
       {
-        let mut map = Map::new();
-        map.assign("keywords", Value::String("Java".into())).unwrap();
+        let mut params = Map::new();
+        params.assign("keywords", Value::String("Java".into())).unwrap();
 
-        let results = Talent::search(&mut client, &*config.es.index, &map);
+        let results = Talent::search(&mut client, &*config.es.index, &params);
         assert_eq!(vec![2, 5], results.ids());
       }
 
       // JavaScript
       {
-        let mut map = Map::new();
-        map.assign("keywords", Value::String("javascript".into())).unwrap();
+        let mut params = Map::new();
+        params.assign("keywords", Value::String("javascript".into())).unwrap();
 
-        let results = Talent::search(&mut client, &*config.es.index, &map);
+        let results = Talent::search(&mut client, &*config.es.index, &params);
         assert_eq!(vec![5], results.ids());
       }
 
       // JavaScript, ClojureScript
       {
-        let mut map = Map::new();
-        map.assign("keywords", Value::String("script".into())).unwrap();
+        let mut params = Map::new();
+        params.assign("keywords", Value::String("script".into())).unwrap();
 
-        let results = Talent::search(&mut client, &*config.es.index, &map);
+        let results = Talent::search(&mut client, &*config.es.index, &params);
         assert_eq!(vec![4, 5], results.ids());
       }
     }
@@ -1011,145 +1026,167 @@ mod tests {
     // Searching for summary
     {
       {
-        let mut map = Map::new();
-        map.assign("keywords", Value::String("right now".into())).unwrap();
+        let mut params = Map::new();
+        params.assign("keywords", Value::String("right now".into())).unwrap();
 
-        let results = Talent::search(&mut client, &*config.es.index, &map);
+        let results = Talent::search(&mut client, &*config.es.index, &params);
         assert_eq!(vec![4], results.ids());
       }
 
       {
-        let mut map = Map::new();
-        map.assign("keywords", Value::String("C++".into())).unwrap();
+        let mut params = Map::new();
+        params.assign("keywords", Value::String("C++".into())).unwrap();
 
-        let results = Talent::search(&mut client, &*config.es.index, &map);
+        let results = Talent::search(&mut client, &*config.es.index, &params);
         assert_eq!(vec![4, 5], results.ids());
       }
 
       {
-        let mut map = Map::new();
-        map.assign("keywords", Value::String("C#".into())).unwrap();
+        let mut params = Map::new();
+        params.assign("keywords", Value::String("C#".into())).unwrap();
 
-        let results = Talent::search(&mut client, &*config.es.index, &map);
+        let results = Talent::search(&mut client, &*config.es.index, &params);
         assert_eq!(vec![5], results.ids());
       }
 
       {
-        let mut map = Map::new();
-        map.assign("keywords", Value::String("rust and".into())).unwrap();
+        let mut params = Map::new();
+        params.assign("keywords", Value::String("rust and".into())).unwrap();
 
-        let results = Talent::search(&mut client, &*config.es.index, &map);
+        let results = Talent::search(&mut client, &*config.es.index, &params);
         assert_eq!(vec![1, 2], results.ids());
       }
     }
 
     // Searching for headline and summary
     {
-      let mut map = Map::new();
-      map.assign("keywords", Value::String("senior".to_owned())).unwrap();
+      let mut params = Map::new();
+      params.assign("keywords", Value::String("senior".to_owned())).unwrap();
 
-      let results = Talent::search(&mut client, &*config.es.index, &map);
+      let results = Talent::search(&mut client, &*config.es.index, &params);
       assert_eq!(vec![2, 4, 1], results.ids());
     }
 
     // Searching for ideal work roles
     {
-      let mut map = Map::new();
-      map.assign("keywords", Value::String("Devops".to_owned())).unwrap();
+      let mut params = Map::new();
+      params.assign("keywords", Value::String("Devops".to_owned())).unwrap();
 
-      let results = Talent::search(&mut client, &*config.es.index, &map);
+      let results = Talent::search(&mut client, &*config.es.index, &params);
       assert_eq!(vec![4, 5], results.ids());
     }
 
     // Searching for previous job title
     {
-      let mut map = Map::new();
-      map.assign("keywords", Value::String("database admin".to_owned())).unwrap();
+      let mut params = Map::new();
+      params.assign("keywords", Value::String("database admin".to_owned())).unwrap();
 
-      let results = Talent::search(&mut client, &*config.es.index, &map);
+      let results = Talent::search(&mut client, &*config.es.index, &params);
       assert_eq!(vec![1, 4], results.ids());
     }
 
     // highlight
     {
-      let mut map = Map::new();
-      map.assign("keywords", Value::String("C#".into())).unwrap();
+      let mut params = Map::new();
+      params.assign("keywords", Value::String("C#".into())).unwrap();
 
-      let results    = Talent::search(&mut client, &*config.es.index, &map).talents;
+      let results    = Talent::search(&mut client, &*config.es.index, &params).talents;
       let highlights = results.into_iter().map(|r| r.highlight.unwrap()).collect::<Vec<HighlightResult>>();
       assert_eq!(Some(&vec![" C#.".to_owned()]), highlights[0].get("summary"));
     }
 
     // filtering for given company_id (skip contacted talents)
     {
-      let mut map = Map::new();
-      map.assign("company_id", Value::String("6".into())).unwrap();
+      let mut params = Map::new();
+      params.assign("company_id", Value::String("6".into())).unwrap();
 
-      let results = Talent::search(&mut client, &*config.es.index, &map);
+      let results = Talent::search(&mut client, &*config.es.index, &params);
       assert_eq!(vec![2, 1], results.ids());
     }
 
     // filtering for given bookmarks (ids)
     {
-      let mut map = Map::new();
-      map.assign("ids[]", Value::U64(2)).unwrap();
-      map.assign("ids[]", Value::U64(4)).unwrap();
-      map.assign("ids[]", Value::U64(1)).unwrap();
-      map.assign("ids[]", Value::U64(3)).unwrap();
-      map.assign("ids[]", Value::U64(5)).unwrap();
-      map.assign("ids[]", Value::U64(6)).unwrap();
-      map.assign("ids[]", Value::U64(7)).unwrap();
-      map.assign("ids[]", Value::U64(8)).unwrap();
+      let mut params = Map::new();
+      params.assign("ids[]", Value::U64(2)).unwrap();
+      params.assign("ids[]", Value::U64(4)).unwrap();
+      params.assign("ids[]", Value::U64(1)).unwrap();
+      params.assign("ids[]", Value::U64(3)).unwrap();
+      params.assign("ids[]", Value::U64(5)).unwrap();
+      params.assign("ids[]", Value::U64(6)).unwrap();
+      params.assign("ids[]", Value::U64(7)).unwrap();
+      params.assign("ids[]", Value::U64(8)).unwrap();
 
-      let results = Talent::search(&mut client, &*config.es.index, &map);
+      let results = Talent::search(&mut client, &*config.es.index, &params);
       assert_eq!(vec![4, 5, 2, 1], results.ids());
       assert_eq!(4, results.total);
     }
 
     // filtering for work_authorization
     {
-      let mut map = Map::new();
-      map.assign("work_authorization[]", Value::String("no".into())).unwrap();
+      let mut params = Map::new();
+      params.assign("work_authorization[]", Value::String("no".into())).unwrap();
 
-      let results = Talent::search(&mut client, &*config.es.index, &map);
+      let results = Talent::search(&mut client, &*config.es.index, &params);
       assert_eq!(vec![4], results.ids());
     }
 
     // ignoring contacted talents
     {
-      let mut map = Map::new();
-      map.assign("contacted_talents[]", Value::String("2".into())).unwrap();
+      let mut params = Map::new();
+      params.assign("contacted_talents[]", Value::String("2".into())).unwrap();
 
-      let results = Talent::search(&mut client, &*config.es.index, &map);
+      let results = Talent::search(&mut client, &*config.es.index, &params);
       assert_eq!(vec![4, 5, 1], results.ids());
     }
 
     // ignoring blocked companies
     {
-      let mut map = Map::new();
-      map.assign("company_id", Value::U64(22)).unwrap();
+      let mut params = Map::new();
+      params.assign("company_id", Value::U64(22)).unwrap();
 
-      let results = Talent::search(&mut client, &*config.es.index, &map);
+      let results = Talent::search(&mut client, &*config.es.index, &params);
       assert_eq!(vec![4, 5, 1], results.ids());
     }
 
     // embedding position scores
     {
       let scores = vec![
-        Score { match_id: "A2-2B-9S".to_owned(), job_id: 1, talent_id: 1, score: 0.545 }
+        Score { match_id: "2A-2B-9S".to_owned(),      job_id: 1, talent_id: 1, score: 0.545 },
+        Score { match_id: "No4-No16-No21".to_owned(), job_id: 1, talent_id: 2, score: 0.454 },
       ];
       assert!(Score::index(&mut client, &config.es.index, scores).is_ok());
 
       refresh_index(&mut client);
 
-      let mut map = Map::new();
-      map.assign("job_id", Value::U64(1)).unwrap();
+      let mut params = Map::new();
+      params.assign("job_id", Value::U64(1)).unwrap();
 
-      // same of the very first test here
-      let results = Talent::search(&mut client, &*config.es.index, &map);
+      let results = Talent::search(&mut client, &*config.es.index, &params);
       assert_eq!(vec![4, 5, 2, 1], results.ids());
-      assert_eq!(4, results.total);
       assert!(results.highlights().iter().all(|r| r.is_none()));
+
+      let     scores_ = results.scores();
+      let mut scores  = scores_.iter();
+      assert!(scores.next().unwrap().is_none());
+      assert!(scores.next().unwrap().is_none());
+      assert!(scores.next().unwrap().is_some());
+
+      let score = scores.next().unwrap();
+      assert_eq!(score.clone().unwrap().score, 0.545);
+    }
+
+    // when deleting a talent, the attached score is deleted too
+    {
+      let search  = ScoreSearchBuilder::new().with_talent_id(1).build();
+      let results = Score::search(&mut client, &config.es.index, &search);
+      assert_eq!(results.total, 1);
+
+      assert!(Talent::delete(&mut client, "1", &*config.es.index).is_ok());
+
+      refresh_index(&mut client);
+
+      let results = Score::search(&mut client, &config.es.index, &search);
+      assert_eq!(results.total, 0);
     }
   }
 


### PR DESCRIPTION
We are creating a new resource called `resources::score` which exposes to the endpoint (`/scores`) only the index action.

`resources::talent` will query (`search`) it in order to get the score inside its `SearchResult` (if `job_id` is given as parameter in the GET request for `/talents`) and `delete` when a talent is deleted.

We also started to use an ES index for each resource so that we won't have race conditions since tests are run in parallel and a `reset_index` is called in both the tests.